### PR TITLE
Update pagecloud key url required by blackfire

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for .
 
-blackfire_package_cloud_key_url: https://packagecloud.io/gpg.key
+blackfire_package_cloud_key_url: https://packagecloud.io/blackfire-io/stable/gpgkey
 
 blackfire_directory: /etc/blackfire


### PR DESCRIPTION
This project is pointed to by the official blackfire intergration page
dealing with ansible docs, but in implementing the steps I noticed
that the code was unable to be built by ansible due to an incorrect
key url.

See Per-repository GPG keys at https://packagecloud.io/docs
for more info.